### PR TITLE
Updated List of CGs page

### DIFF
--- a/_suppliers/supplying-controlled-goods/list-of-controlled-goods.md
+++ b/_suppliers/supplying-controlled-goods/list-of-controlled-goods.md
@@ -668,27 +668,8 @@ gas.</p>
 <p><u>Hose</u>
 <br>SS 233: 2013
 <br>
-<br>
-<br>
-<br>
-</p>
-<p></p>
-<p></p>
-<p></p>
-<p></p>
-<p><u>Regulator</u>
+<br><u>Regulator</u>
 <br>SS 281: 1984</p>
-<p>
-<br>
-<br>
-</p>
-<p></p>
-<p></p>
-<p></p>
-<p>
-<br>
-</p>
-<p></p>
 <p></p>
 <p><u>Valve</u>
 <br>SS 294: 1998</p>


### PR DESCRIPTION
- Updated the safety standards and definitions of CGs based on the CPS Infobook
- Added the following para before the tables of CGs (CPS Infobook is hyperlinked):
"For the full requirements for CGs (including additional ones besides the safety standards stated in the tables below), please refer to the Consumer Protection (Safety Requirements) Regulations Information Booklet."