### PR TITLE
Removal of link to consumer survey on 6 pages

### DIFF
--- a/_consumers/choose-safer-products/choose-safer-consumer-goods.md
+++ b/_consumers/choose-safer-products/choose-safer-consumer-goods.md
@@ -2,36 +2,96 @@
 title: Choose safer consumer goods
 permalink: /consumers/choose-safer-products/choose-safer-consumer-goods/
 third_nav_title: Choose safer products
-variant: markdown
+variant: tiptap
 ---
-## Products that do not require a SAFETY Mark
-Consumer goods such as toys, children’s products, apparel, sports and recreation products, furniture, mattresses and bedding and DIY tools, which are not regulated under other product safety Regulations, fall under the Consumer Protection (Consumer Goods Safety Requirements) Regulations (CGSR). Consumer goods under the CGSR do not require pre-market approval by the authority. However, they must comply with international safety standards such as:
-
-* International Organization for Standardization (ISO)
-* International Electrotechnical Commission (IEC)
-* European Committee for Standardisation
-* ASTM International
-
-Regional or national standards may also be accepted for consumer goods that do not have applicable international safety standards.
-
-The Consumer Product Safety Office does active post-market surveillance to reduce the impact of unsafe general consumer goods as soon as safety issues are discovered. Consumers may refer to the [Product Safety Alerts and Recalls page](/consumers/safety-alerts-and-recalls/children-apparel) for the latest news regarding unsafe consumer products identified in Singapore. 
-
-**When purchasing consumer goods, consumers are encouraged to:**
-* Avoid making your decision to purchase any item solely based on price. Product safety is of equal importance in the consideration process.
-* Research on the type of product you want to buy and gather tips on what to look out for.
-* Check the product's description, its functions and age recommendations.
-* Buy from reputable retailers and when making an online purchase, check if the product meets safety standards and is suitable for local use.
-* Check if the product comes with instructions and manufacturer/distributor information.
-* Inspect the product you are buying for any damage. Look out for sharp edges as well as loose or missing parts.
-
-**Use products safely** 
-* Read safety warnings and instructions on assembly, installation, usage and maintenance. Follow them strictly.
-* Use products only for their intended purpose.
-* Do not make assumptions on how to use a product just because you have used a similar product in the past. Always refer to the safety information supplied.
-* Ask the seller for help if the product’s intended use or instructions are not clear.
-* Assess if children need to be supervised when using a product.
-* Assess if you need to keep a product out of the reach of young children.
-* Stop using the product when signs of wear and tear such as cracks are observed.
-* Do not use electrical appliances near wet areas and bathtubs, basins or other vessels containing water.
-
-Click [here](/consumers/product-safety-tips/electronics-and-appliances) for more consumer product safety tips.
+<h2>Products that do not require a SAFETY Mark</h2>
+<p>Consumer goods such as toys, children’s products, apparel, sports and
+recreation products, furniture, mattresses and bedding and DIY tools, which
+are not regulated under other product safety Regulations, fall under the
+Consumer Protection (Consumer Goods Safety Requirements) Regulations (CGSR).
+Consumer goods under the CGSR do not require pre-market approval by the
+authority. However, they must comply with international safety standards
+such as:</p>
+<ul data-tight="true" class="tight">
+<li>
+<p>International Organization for Standardization (ISO)</p>
+</li>
+<li>
+<p>International Electrotechnical Commission (IEC)</p>
+</li>
+<li>
+<p>European Committee for Standardisation</p>
+</li>
+<li>
+<p>ASTM International</p>
+</li>
+</ul>
+<p>Regional or national standards may also be accepted for consumer goods
+that do not have applicable international safety standards.</p>
+<p>The Consumer Product Safety Office does active post-market surveillance
+to reduce the impact of unsafe general consumer goods as soon as safety
+issues are discovered. Consumers may refer to the <a href="https://www.consumerproductsafety.gov.sg/consumers/safety-alerts-and-recalls/children-apparel/" rel="noopener noreferrer nofollow" target="_blank">Product Safety Alerts and Recalls page</a> for
+the latest news regarding unsafe consumer products identified in Singapore.</p>
+<p><strong>When purchasing consumer goods, consumers are encouraged to:</strong>
+</p>
+<ul data-tight="true" class="tight">
+<li>
+<p>Avoid making your decision to purchase any item solely based on price.
+Product safety is of equal importance in the consideration process.</p>
+</li>
+<li>
+<p>Research on the type of product you want to buy and gather tips on what
+to look out for.</p>
+</li>
+<li>
+<p>Check the product's description, its functions and age recommendations.</p>
+</li>
+<li>
+<p>Buy from reputable retailers and when making an online purchase, check
+if the product meets safety standards and is suitable for local use.</p>
+</li>
+<li>
+<p>Check if the product comes with instructions and manufacturer/distributor
+information.</p>
+</li>
+<li>
+<p>Inspect the product you are buying for any damage. Look out for sharp
+edges as well as loose or missing parts.</p>
+</li>
+</ul>
+<p><strong>Use products safely</strong>
+</p>
+<ul data-tight="true" class="tight">
+<li>
+<p>Read safety warnings and instructions on assembly, installation, usage
+and maintenance. Follow them strictly.</p>
+</li>
+<li>
+<p>Use products only for their intended purpose.</p>
+</li>
+<li>
+<p>Do not make assumptions on how to use a product just because you have
+used a similar product in the past. Always refer to the safety information
+supplied.</p>
+</li>
+<li>
+<p>Ask the seller for help if the product’s intended use or instructions
+are not clear.</p>
+</li>
+<li>
+<p>Assess if children need to be supervised when using a product.</p>
+</li>
+<li>
+<p>Assess if you need to keep a product out of the reach of young children.</p>
+</li>
+<li>
+<p>Stop using the product when signs of wear and tear such as cracks are
+observed.</p>
+</li>
+<li>
+<p>Do not use electrical appliances near wet areas and bathtubs, basins or
+other vessels containing water.</p>
+</li>
+</ul>
+<p>Click <a href="https://www.consumerproductsafety.gov.sg/consumers/product-safety-tips/electronics-and-appliances/" rel="noopener noreferrer nofollow" target="_blank">here</a> for
+more consumer product safety tips.</p>

--- a/_consumers/choose-safer-products/choose-safer-consumer-goods.md
+++ b/_consumers/choose-safer-products/choose-safer-consumer-goods.md
@@ -2,8 +2,8 @@
 title: Choose safer consumer goods
 permalink: /consumers/choose-safer-products/choose-safer-consumer-goods/
 third_nav_title: Choose safer products
+variant: markdown
 ---
-*Help us better understand consumer habits so that we can improve the effectiveness of our safety regimes. Please spare 5 mins to fill out this [simple survey](https://form.gov.sg/63a160c3cf15ee00129a4ab4)*
 ## Products that do not require a SAFETY Mark
 Consumer goods such as toys, children’s products, apparel, sports and recreation products, furniture, mattresses and bedding and DIY tools, which are not regulated under other product safety Regulations, fall under the Consumer Protection (Consumer Goods Safety Requirements) Regulations (CGSR). Consumer goods under the CGSR do not require pre-market approval by the authority. However, they must comply with international safety standards such as:
 

--- a/_consumers/choose-safer-products/look-for-the-safety-mark.md
+++ b/_consumers/choose-safer-products/look-for-the-safety-mark.md
@@ -4,13 +4,10 @@ permalink: /consumers/choose-safer-products/look-for-the-safety-mark/
 third_nav_title: Choose safer products
 variant: tiptap
 ---
-<p><em>Help us better understand consumer habits so that we can improve the effectiveness of our safety regimes. Please spare 5 mins to fill out this <a href="https://form.gov.sg/63a160c3cf15ee00129a4ab4" rel="noopener noreferrer nofollow" target="_blank">simple survey</a></em>
-</p>
-<p></p>
 <h2>Controlled Goods Must have the SAFETY Mark</h2>
-<p>Consumers can do their part in keeping their families safe by looking
-out for the SAFETY Mark when purchasing household electrical, electronic
-and gas appliances.</p>
+<p>Consumers can do their part in keeping their families safe by out for
+the SAFETY Mark when purchasing household electrical, electronic and gas
+appliances.</p>
 <p></p>
 <div data-type="detailGroup" class="isomer-accordion isomer-accordion-white">
 <details class="isomer-details">
@@ -394,6 +391,5 @@ safely. Click <a href="http://www.consumerproductsafety.gov.sg/consumers/product
 </div>
 </details>
 </div>
-<p></p>
 <p></p>
 <p></p>

--- a/_consumers/choose-safer-products/shopping-for-safe-products-online.md
+++ b/_consumers/choose-safer-products/shopping-for-safe-products-online.md
@@ -2,28 +2,75 @@
 title: Shopping for safe products online
 permalink: /consumers/choose-safer-products/shopping-for-safe-products-online/
 third_nav_title: Choose safer products
-variant: markdown
+variant: tiptap
 ---
-*Help us better understand consumer habits so that we can improve the effectiveness of our safety regimes. Please spare 5 mins to fill out this [simple survey](https://form.gov.sg/63a160c3cf15ee00129a4ab4)*
-## What to Look out for When Buying from Online or Overseas Retailers
-The affordability and wide selection of household products available online is very attractive to those in search of a bargain. Many new homeowners arrange bulk purchases or rely on home renovation contractors to source for appliances and furniture, most of which are bought overseas.
-
-However, homeowners need to be aware that safety regulations can vary greatly from country to country. You may not be adequately protected should you decide to buy from an overseas retailer. Always ask if a product meets local safety requirements.
-
-Here are some tips to keep in mind when buying home appliances and electronics online:
-<img src="/images/about-us/safety-mark.jpg" alt="SAFETY Mark" style="width:363.5px;height:210px;">
-General household items such as electrical, electronic and gas appliances under Consumer Protection (Safety Requirements) Regulations need to carry the SAFETY Mark before they can be sold in Singapore. Click [here](https://www.consumerproductsafety.gov.sg/consumers/choose-safer-products/look-for-the-safety-mark/) to learn more about the types of household items which requires a SAFETY Mark. <br><br> Photos from online marketplaces may show limited product angles so when in doubt, always ask the seller if the product has been tested for safety and **bears a SAFETY Mark.**
-<img src="/images/consumers/choose-safer-products/shopping-online/ask-questions.png" style="width:200px;height:200px;"><br>If the product description, pictures or videos do not clearly explain its features and functionality, never hesitate to contact the seller for more details.
-<img src="/images/consumers/choose-safer-products/shopping-online/do-your-homework.png" style="width:200px;height:200px;"><br>A quick search online can often help reveal products that have been recalled by the manufacturer or had its sale stopped by regulatory bodies over safety issues. In addition to price, check out past buyers’ feedback, seller ratings and independent product reviews to thoroughly make sure no safety hazards or reliability issues exist.
-<img src="/images/consumers/choose-safer-products/shopping-online/buy-from-official-stores-or-reputable-online-marketplaces.png" style="width:200px;height:200px;"><br>Look for a seller that provides full product warranty by the manufacturer, customer service support and a return or exchange policy.
-<img src="/images/consumers/choose-safer-products/shopping-online/is-it-designed-for-use-in-singapore.png" style="width:200px;height:200px;"><br>When buying electrical appliances online, technical specifications printed on the packaging may not be shown on the product page. Always contact the seller to ensure that it comes with plugs and voltages that are suitable for use locally. Do also check that the electrical appliance is defined as a Controlled Good, which is required to be affixed with a SAFETY Mark. You can check if the SAFETY Mark number is valid by keying in the details at the [Register of Registered Controlled Goods](https://www.cpsaplus.gov.sg/Homepage/RegisterOfRegisteredControlledGoods).
-
-In support of the Organisation for Economic Coorperation and Development's [Global Awareness Campaign on online safety](https://www.oecd.org/digital/consumer/put-product-safety-first/), the CPSO encourages consumers to #PutProductSafetyFirst when buying products online. Here are additional tips to consider when making purchases online:
-
-Before purchase:
-![OECD1](/images/consumers/oecd-checklist-before-purchase-ls.png)
-
-After purchase:
-![OECD1](/images/consumers/oecd-checklist-after-purchase-ls.png)
-	
-You can find more information on the OECD's work consumer product safety [here](https://www.oecd.org/sti/consumer/consumer-product-safety.htm).
+<h2>What to Look out for When Buying from Online or Overseas Retailers</h2>
+<p>The affordability and wide selection of household products available online
+is very attractive to those in search of a bargain. Many new homeowners
+arrange bulk purchases or rely on home renovation contractors to source
+for appliances and furniture, most of which are bought overseas.</p>
+<p>However, homeowners need to be aware that safety regulations can vary
+greatly from country to country. You may not be adequately protected should
+you decide to buy from an overseas retailer. Always ask if a product meets
+local safety requirements.</p>
+<p>Here are some tips to keep in mind when buying home appliances and electronics
+online:</p>
+<div class="isomer-image-wrapper">
+<img style="width:363.5px;height:210px;" height="auto" width="100%" alt="SAFETY Mark" src="/images/about-us/safety-mark.jpg">
+</div>
+<p>General household items such as electrical, electronic and gas appliances
+under Consumer Protection (Safety Requirements) Regulations need to carry
+the SAFETY Mark before they can be sold in Singapore. Click <a href="https://www.consumerproductsafety.gov.sg/consumers/choose-safer-products/look-for-the-safety-mark/" rel="noopener noreferrer nofollow" target="_blank">here</a> to
+learn more about the types of household items which requires a SAFETY Mark.
+<br>
+<br>Photos from online marketplaces may show limited product angles so when
+in doubt, always ask the seller if the product has been tested for safety
+and <strong>bears a SAFETY Mark.</strong>
+</p>
+<div class="isomer-image-wrapper">
+<img style="width:200px;height:200px;" height="auto" width="100%" src="/images/consumers/choose-safer-products/shopping-online/ask-questions.png">
+</div>
+<p>
+<br>If the product description, pictures or videos do not clearly explain
+its features and functionality, never hesitate to contact the seller for
+more details.</p>
+<div class="isomer-image-wrapper">
+<img style="width:200px;height:200px;" height="auto" width="100%" src="/images/consumers/choose-safer-products/shopping-online/do-your-homework.png">
+</div>
+<p>
+<br>A quick search online can often help reveal products that have been recalled
+by the manufacturer or had its sale stopped by regulatory bodies over safety
+issues. In addition to price, check out past buyers’ feedback, seller ratings
+and independent product reviews to thoroughly make sure no safety hazards
+or reliability issues exist.</p>
+<div class="isomer-image-wrapper">
+<img style="width:200px;height:200px;" height="auto" width="100%" src="/images/consumers/choose-safer-products/shopping-online/buy-from-official-stores-or-reputable-online-marketplaces.png">
+</div>
+<p>
+<br>Look for a seller that provides full product warranty by the manufacturer,
+customer service support and a return or exchange policy.</p>
+<div class="isomer-image-wrapper">
+<img style="width:200px;height:200px;" height="auto" width="100%" src="/images/consumers/choose-safer-products/shopping-online/is-it-designed-for-use-in-singapore.png">
+</div>
+<p>
+<br>When buying electrical appliances online, technical specifications printed
+on the packaging may not be shown on the product page. Always contact the
+seller to ensure that it comes with plugs and voltages that are suitable
+for use locally. Do also check that the electrical appliance is defined
+as a Controlled Good, which is required to be affixed with a SAFETY Mark.
+You can check if the SAFETY Mark number is valid by keying in the details
+at the <a href="https://www.cpsaplus.gov.sg/Homepage/RegisterOfRegisteredControlledGoods" rel="noopener noreferrer nofollow" target="_blank">Register of Registered Controlled Goods</a>.</p>
+<p>In support of the Organisation for Economic Coorperation and Development's
+<a href="https://www.oecd.org/digital/consumer/put-product-safety-first/" rel="noopener noreferrer nofollow" target="_blank">Global Awareness Campaign on online safety</a>, the CPSO encourages consumers
+to #PutProductSafetyFirst when buying products online. Here are additional
+tips to consider when making purchases online:</p>
+<p>Before purchase:</p>
+<div class="isomer-image-wrapper">
+<img style="width: 100%" height="auto" width="100%" alt="OECD1" src="/images/consumers/oecd-checklist-before-purchase-ls.png">
+</div>
+<p>After purchase:</p>
+<div class="isomer-image-wrapper">
+<img style="width: 100%" height="auto" width="100%" alt="OECD1" src="/images/consumers/oecd-checklist-after-purchase-ls.png">
+</div>
+<p>You can find more information on the OECD's work consumer product safety
+<a href="https://www.oecd.org/sti/consumer/consumer-product-safety.htm" rel="noopener noreferrer nofollow" target="_blank">here</a>.</p>

--- a/_consumers/product-safety-tips/Home appliances, furniture, and indoor product safety.md
+++ b/_consumers/product-safety-tips/Home appliances, furniture, and indoor product safety.md
@@ -5,8 +5,6 @@ third_nav_title: Product safety tips
 variant: tiptap
 description: ""
 ---
-<p><em>Help us better understand consumer habits so that we can improve the effectiveness of our safety regimes. Please spare 5 mins to fill out this <a href="https://form.gov.sg/63a160c3cf15ee00129a4ab4" rel="noopener noreferrer nofollow" target="_blank">simple survey</a></em>
-</p>
 <h2>Safety at home</h2>
 <p>It is important to consider safety when choosing appliances, electronics,
 and furniture for your home. Dangers can arise from choosing unsafe products,

--- a/_consumers/product-safety-tips/Products that charge or power appliances.md
+++ b/_consumers/product-safety-tips/Products that charge or power appliances.md
@@ -5,8 +5,6 @@ third_nav_title: Product safety tips
 variant: tiptap
 description: ""
 ---
-<p><em>Help us better understand consumer habits so that we can improve the effectiveness of our safety regimes. Please spare 5 mins to fill out this <a href="https://form.gov.sg/63a160c3cf15ee00129a4ab4" rel="noopener noreferrer nofollow" target="_blank">simple survey</a></em>
-</p>
 <h2>Safety tips for products that charge or power appliances</h2>
 <p>We use a variety of products to charge or power electrical appliances
 in our daily lives. Overlooking basic product safety practices can lead

--- a/_consumers/product-safety-tips/children-s-products.md
+++ b/_consumers/product-safety-tips/children-s-products.md
@@ -4,8 +4,6 @@ permalink: /consumers/product-safety-tips/children-product/
 third_nav_title: Product safety tips
 variant: tiptap
 ---
-<p><em>Help us better understand consumer habits so that we can improve the effectiveness of our safety regimes. Please spare 5 mins to fill out this <a href="https://form.gov.sg/63a160c3cf15ee00129a4ab4" rel="noopener noreferrer nofollow" target="_blank">simple survey</a></em>
-</p>
 <h2>Safety tips for children's products</h2>
 <p>Children and toddlers belong to a vulnerable group and require greater
 care when using products. Keep the following product safety tips in mind


### PR DESCRIPTION
The link to the consumer survey was removed from the following pages:

- https://www.consumerproductsafety.gov.sg/consumers/choose-safer-products/look-for-the-safety-mark/
- https://www.consumerproductsafety.gov.sg/consumers/choose-safer-products/choose-safer-consumer-goods/
- https://www.consumerproductsafety.gov.sg/consumers/choose-safer-products/shopping-for-safe-products-online/
- https://www.consumerproductsafety.gov.sg/consumers/product-safety-tips/electronics-and-appliances/
- https://www.consumerproductsafety.gov.sg/consumers/product-safety-tips/home-appliances-and-furniture/
- https://www.consumerproductsafety.gov.sg/consumers/product-safety-tips/children-product/