### PR TITLE
Updated tips on mains plugs

### DIFF
--- a/pages/2j-types-of-mains-plugs-suitable-for-use-in-singapore.md
+++ b/pages/2j-types-of-mains-plugs-suitable-for-use-in-singapore.md
@@ -41,7 +41,7 @@ ensure that its mains plug carries a SAFETY Mark.</p>
 <p><strong>Caution: Schuko plugs</strong>
 </p>
 <div class="isomer-image-wrapper">
-<img style="width: 30%;" height="auto" width="100%" alt="mains plugs 4" src="/images/consumers/did-you-know/types-of-mains-plugs/mains-plugs-4.jpg">
+<img style="width: 25%;" height="auto" width="100%" alt="mains plugs 4" src="/images/consumers/did-you-know/types-of-mains-plugs/mains-plugs-4.jpg">
 </div>
 <p>Some appliances are fitted with mains plugs meant for the German market.
 These are <strong>rated at 10/16AMP</strong> and known as <strong>‘Schuko’</strong> plugs

--- a/pages/2j-types-of-mains-plugs-suitable-for-use-in-singapore.md
+++ b/pages/2j-types-of-mains-plugs-suitable-for-use-in-singapore.md
@@ -13,7 +13,7 @@ socket to avoid hazards such as fires and electrocution.</p>
 <p><strong>3 types of mains plugs suitable for use in Singapore</strong>
 </p>
 <div class="isomer-image-wrapper">
-<img style="width: 100%" height="auto" width="100%" alt="mains plugs 1" src="/images/consumers/did-you-know/types-of-mains-plugs/mains-plugs-1.jpg">
+<img style="width: 30%;" height="auto" width="100%" alt="mains plugs 1" src="/images/consumers/did-you-know/types-of-mains-plugs/mains-plugs-1.jpg">
 </div>
 <p><strong>(1) The 2.5AMP 2 round-pin mains plug</strong> – This is generally
 used for electronics appliances such as TV, DVD and audio sets. These appliances
@@ -21,7 +21,7 @@ do not rely on the ‘Earth’ wire for protection from a short circuit and
 therefore only 2 pins are needed – one for the ‘Live’ wire and the other
 for the ‘Neutral’ wire.| |</p>
 <div class="isomer-image-wrapper">
-<img style="width: 100%" height="auto" width="100%" alt="mains plugs 2" src="/images/consumers/did-you-know/types-of-mains-plugs/mains-plugs-2.jpg">
+<img style="width: 30%;" height="auto" width="100%" alt="mains plugs 2" src="/images/consumers/did-you-know/types-of-mains-plugs/mains-plugs-2.jpg">
 </div>
 <p><strong>(2) The 13AMP 3 pin fused mains plug</strong> – This is used for
 electrical appliances such as refrigerators, washing machines and microwave
@@ -29,7 +29,7 @@ ovens. These appliances have a metal body which must be grounded so that
 in the event of a short circuit, there is no risk of electrocution to the
 user.| |</p>
 <div class="isomer-image-wrapper">
-<img style="width: 100%" height="auto" width="100%" alt="mains plugs 3" src="/images/consumers/did-you-know/types-of-mains-plugs/mains-plugs-3.jpg">
+<img style="width: 30%;" height="auto" width="100%" alt="mains plugs 3" src="/images/consumers/did-you-know/types-of-mains-plugs/mains-plugs-3.jpg">
 </div>
 <p><strong>(3) The 15AMP 3 round-pin mains plug</strong> – This is used generally
 for air-conditioners.</p>
@@ -41,7 +41,7 @@ ensure that its mains plug carries a SAFETY Mark.</p>
 <p><strong>Caution: Schuko plugs</strong>
 </p>
 <div class="isomer-image-wrapper">
-<img style="width: 100%" height="auto" width="100%" alt="mains plugs 4" src="/images/consumers/did-you-know/types-of-mains-plugs/mains-plugs-4.jpg">
+<img style="width: 30%;" height="auto" width="100%" alt="mains plugs 4" src="/images/consumers/did-you-know/types-of-mains-plugs/mains-plugs-4.jpg">
 </div>
 <p>Some appliances are fitted with mains plugs meant for the German market.
 These are <strong>rated at 10/16AMP</strong> and known as <strong>‘Schuko’</strong> plugs
@@ -54,18 +54,16 @@ strips cannot make contact with the earth contact of a local mains socket.</p>
 <p><strong>Examples of suitable mains plugs</strong>
 </p>
 <div class="isomer-image-wrapper">
-<img style="width: 100%" height="auto" width="100%" alt="mains plugs 5" src="/images/consumers/did-you-know/types-of-mains-plugs/mains-plugs-5.jpg">
+<img style="width: 50%;" height="auto" width="100%" alt="mains plugs 5" src="/images/consumers/did-you-know/types-of-mains-plugs/mains-plugs-5.jpg">
 </div>
-<p>
-<br><em>From left to right: 2.5A round pin, 13A rectangular pin, 15A round pin</em>
+<p><em>From left to right: 2.5A round pin, 13A rectangular pin, 15A round pin</em>
 </p>
 <p><strong>Examples of not suitable mains plugs</strong>
 </p>
 <div class="isomer-image-wrapper">
 <img style="width: 100%" height="auto" width="100%" alt="non approved mains plugs" src="/images/consumers/did-you-know/types-of-mains-plugs/non-approved-mains-plugs.jpg">
 </div>
-<p>
-<br><em>From left to right: Flat-blade plug, Schuko plug with side grounding contact, Schuko plug with side grounding contact, 10/16-Amp round pin, Flat-blade but with round grounding pin, Flat-blade but with round grounding pin</em>
+<p><em>From left to right: Flat-blade plug, Schuko plug with side grounding contact, Schuko plug with side grounding contact, 10/16-Amp round pin, Flat-blade but with round grounding pin, Flat-blade but with round grounding pin</em>
 </p>
 <p><strong><a href="/consumers/product-safety-tips/home-appliances-and-furniture" rel="noopener noreferrer nofollow" target="_blank">← Back to Product safety tips</a></strong>
 </p>

--- a/pages/2j-types-of-mains-plugs-suitable-for-use-in-singapore.md
+++ b/pages/2j-types-of-mains-plugs-suitable-for-use-in-singapore.md
@@ -6,8 +6,8 @@ variant: tiptap
 <p><strong><a href="https://www.consumerproductsafety.gov.sg/consumers/product-safety-tips/home-appliances-and-furniture/" rel="noopener noreferrer nofollow" target="_blank">← Back to Product safety tips</a></strong>
 </p>
 <h2>Type of Mains Plugs Suitable for use in Singapore</h2>
-<p>Apart from Brunei, Hong Kong, Malaysia or UK, mains plugs that are used
-in other countries are different from those intended for use in Singapore.
+<p>Apart from Brunei, Hong Kong, Malaysia or the UK, mains plugs that are
+used in other countries are different from those intended for use in Singapore.
 It is important to ensure that the correct plug is used with a local wall
 socket to avoid hazards such as fires and electrocution.</p>
 <p><strong>3 types of mains plugs suitable for use in Singapore</strong>

--- a/pages/2j-types-of-mains-plugs-suitable-for-use-in-singapore.md
+++ b/pages/2j-types-of-mains-plugs-suitable-for-use-in-singapore.md
@@ -27,7 +27,7 @@ for the ‘Neutral’ wire.</p>
 electrical appliances such as refrigerators, washing machines and microwave
 ovens. These appliances have a metal body which must be grounded so that
 in the event of a short circuit, there is no risk of electrocution to the
-user.| |</p>
+user.</p>
 <div class="isomer-image-wrapper">
 <img style="width: 30%;" height="auto" width="100%" alt="mains plugs 3" src="/images/consumers/did-you-know/types-of-mains-plugs/mains-plugs-3.jpg">
 </div>

--- a/pages/2j-types-of-mains-plugs-suitable-for-use-in-singapore.md
+++ b/pages/2j-types-of-mains-plugs-suitable-for-use-in-singapore.md
@@ -19,7 +19,7 @@ socket to avoid hazards such as fires and electrocution.</p>
 used for electronics appliances such as TV, DVD and audio sets. These appliances
 do not rely on the ‘Earth’ wire for protection from a short circuit and
 therefore only 2 pins are needed – one for the ‘Live’ wire and the other
-for the ‘Neutral’ wire.| |</p>
+for the ‘Neutral’ wire.</p>
 <div class="isomer-image-wrapper">
 <img style="width: 30%;" height="auto" width="100%" alt="mains plugs 2" src="/images/consumers/did-you-know/types-of-mains-plugs/mains-plugs-2.jpg">
 </div>

--- a/pages/2j-types-of-mains-plugs-suitable-for-use-in-singapore.md
+++ b/pages/2j-types-of-mains-plugs-suitable-for-use-in-singapore.md
@@ -45,7 +45,7 @@ ensure that its mains plug carries a SAFETY Mark.</p>
 </div>
 <p>Some appliances are fitted with mains plugs meant for the German market.
 These are <strong>rated at 10/16AMP</strong> and known as <strong>‘Schuko’</strong> plugs
-(<em>See image</em>). This type of mains plug is <strong>not suitable for use in Singapore</strong>.
+(<em>see image</em>). This type of mains plug is <strong>not suitable for use in Singapore</strong>.
 The dimension of the round pins will stress the contacts of the mains socket
 outlet, subsequently leading to poor contact and overheating.</p>
 <p>Furthermore, while ‘Schuko’ plugs may come with earthing strips located


### PR DESCRIPTION
The following changes were made:
- Resized the images of the plugs as they were automatically enlarged by Isomer when the page was switched to the new editor
- minor editorial changes (e.g. removed '| |' at the end of the captions of the pictures of the first 2 plugs, added "the" next to "UK" in the first line)