### PR TITLE
Added a note with the active CGs list on two pages due to the CPSA+ blackout

### DIFF
--- a/_consumers/choose-safer-products/look-for-the-safety-mark.md
+++ b/_consumers/choose-safer-products/look-for-the-safety-mark.md
@@ -88,6 +88,9 @@ on them. One on the appliance and another on the plug.</p>
 <td rowspan="1" colspan="1">
 <p>Visit <a href="https://www.go.gov.sg/safety-mark" rel="noopener noreferrer nofollow" target="_blank">go.gov.sg/safety-mark</a> to
 access the Register of Registered Controlled Goods.</p>
+<p></p>
+<p><strong>Note: </strong>Our Register is down now. Please check this file,
+for the Controlled Goods with active registrations as of<strong> 9 June 2026, 5pm</strong>.</p>
 </td>
 </tr>
 <tr>

--- a/_consumers/choose-safer-products/look-for-the-safety-mark.md
+++ b/_consumers/choose-safer-products/look-for-the-safety-mark.md
@@ -89,7 +89,7 @@ on them. One on the appliance and another on the plug.</p>
 <p>Visit <a href="https://www.go.gov.sg/safety-mark" rel="noopener noreferrer nofollow" target="_blank">go.gov.sg/safety-mark</a> to
 access the Register of Registered Controlled Goods.</p>
 <p></p>
-<p><strong>Note: </strong>Our Register is down now. Please check <a href="/files/Active_CG_registrations_as_of_9_Jun_2026__5pm.pdf" rel="noopener nofollow" target="_blank">this file</a>,
+<p><strong>Note: </strong>Our Register is down now. Please check <strong><a href="/files/Active_CG_registrations_as_of_9_Jun_2026__5pm.pdf" rel="noopener nofollow" target="_blank">this file</a></strong>,
 for the Controlled Goods with active registrations as of<strong> 9 June 2026, 5pm</strong>.</p>
 </td>
 </tr>

--- a/_consumers/choose-safer-products/look-for-the-safety-mark.md
+++ b/_consumers/choose-safer-products/look-for-the-safety-mark.md
@@ -395,5 +395,4 @@ safely. Click <a href="http://www.consumerproductsafety.gov.sg/consumers/product
 </details>
 </div>
 <p></p>
-<p><a href="/files/Active_CG_registrations_as_of_9_Jun_2026__5pm.pdf" rel="noopener nofollow" target="_blank">file</a>
-</p>
+<p></p>

--- a/_consumers/choose-safer-products/look-for-the-safety-mark.md
+++ b/_consumers/choose-safer-products/look-for-the-safety-mark.md
@@ -89,7 +89,7 @@ on them. One on the appliance and another on the plug.</p>
 <p>Visit <a href="https://www.go.gov.sg/safety-mark" rel="noopener noreferrer nofollow" target="_blank">go.gov.sg/safety-mark</a> to
 access the Register of Registered Controlled Goods.</p>
 <p></p>
-<p><strong>Note: </strong>Our Register is down now. Please check this file,
+<p><strong>Note: </strong>Our Register is down now. Please check <strong>this file</strong>,
 for the Controlled Goods with active registrations as of<strong> 9 June 2026, 5pm</strong>.</p>
 </td>
 </tr>
@@ -395,4 +395,5 @@ safely. Click <a href="http://www.consumerproductsafety.gov.sg/consumers/product
 </details>
 </div>
 <p></p>
-<p></p>
+<p><a href="/files/Active_CG_registrations_as_of_9_Jun_2026__5pm.pdf" rel="noopener nofollow" target="_blank">file</a>
+</p>

--- a/_consumers/choose-safer-products/look-for-the-safety-mark.md
+++ b/_consumers/choose-safer-products/look-for-the-safety-mark.md
@@ -89,7 +89,7 @@ on them. One on the appliance and another on the plug.</p>
 <p>Visit <a href="https://www.go.gov.sg/safety-mark" rel="noopener noreferrer nofollow" target="_blank">go.gov.sg/safety-mark</a> to
 access the Register of Registered Controlled Goods.</p>
 <p></p>
-<p><strong>Note: </strong>Our Register is down now. Please check <strong>this file</strong>,
+<p><strong>Note: </strong>Our Register is down now. Please check <a href="/files/Active_CG_registrations_as_of_9_Jun_2026__5pm.pdf" rel="noopener nofollow" target="_blank">this file</a>,
 for the Controlled Goods with active registrations as of<strong> 9 June 2026, 5pm</strong>.</p>
 </td>
 </tr>

--- a/_suppliers/supplying-controlled-goods/consumer-protection-safety-requirements-regulations.md
+++ b/_suppliers/supplying-controlled-goods/consumer-protection-safety-requirements-regulations.md
@@ -59,8 +59,8 @@ models.</p>
 <p>Visit <a href="https://www.go.gov.sg/safety-mark" rel="noopener noreferrer nofollow" target="_blank">go.gov.sg/safety-mark</a> and
 click on "Register of Registered Controlled Goods"</p>
 <p></p>
-<p><strong>Note: </strong>Our Register is down now. Please check , for the
-Controlled Goods with active registrations as of<strong> 9 June 2026, 5pm</strong>.</p>
+<p><strong>Note: </strong>Our Register is down now. Please check <strong><a href="/files/Active_CG_registrations_as_of_9_Jun_2026__5pm.pdf" rel="noopener nofollow" target="_blank">this file</a></strong>,
+for the Controlled Goods with active registrations as of<strong> 9 June 2026, 5pm</strong>.</p>
 </td>
 </tr>
 <tr>

--- a/_suppliers/supplying-controlled-goods/consumer-protection-safety-requirements-regulations.md
+++ b/_suppliers/supplying-controlled-goods/consumer-protection-safety-requirements-regulations.md
@@ -58,6 +58,9 @@ models.</p>
 <td rowspan="1" colspan="1">
 <p>Visit <a href="https://www.go.gov.sg/safety-mark" rel="noopener noreferrer nofollow" target="_blank">go.gov.sg/safety-mark</a> and
 click on "Register of Registered Controlled Goods"</p>
+<p></p>
+<p><strong>Note: </strong>Our Register is down now. Please check , for the
+Controlled Goods with active registrations as of<strong> 9 June 2026, 5pm</strong>.</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
Added a note with the Active CGs List (as of 9 Jun 2026, 5pm) to the following pages due to the CPSA+ blackout:

1. Safety Mark page (under "How do you check the validity of the product’s SAFETY Mark?")

2. Overview of CPSR page for suppliers (at the table on how to check the validity of the SAFETY Mark)