### PR TITLE
Removed Active CGs List from two webpages

### DIFF
--- a/_consumers/choose-safer-products/look-for-the-safety-mark.md
+++ b/_consumers/choose-safer-products/look-for-the-safety-mark.md
@@ -88,9 +88,6 @@ on them. One on the appliance and another on the plug.</p>
 <td rowspan="1" colspan="1">
 <p>Visit <a href="https://www.go.gov.sg/safety-mark" rel="noopener noreferrer nofollow" target="_blank">go.gov.sg/safety-mark</a> to
 access the Register of Registered Controlled Goods.</p>
-<p></p>
-<p><strong>Note: </strong>Our Register is down now. Please check <strong><a href="/files/Active_CG_registrations_as_of_9_Jun_2026__5pm.pdf" rel="noopener nofollow" target="_blank">this file</a></strong>,
-for the Controlled Goods with active registrations as of<strong> 9 June 2026, 5pm</strong>.</p>
 </td>
 </tr>
 <tr>

--- a/_suppliers/supplying-controlled-goods/consumer-protection-safety-requirements-regulations.md
+++ b/_suppliers/supplying-controlled-goods/consumer-protection-safety-requirements-regulations.md
@@ -57,10 +57,7 @@ models.</p>
 </td>
 <td rowspan="1" colspan="1">
 <p>Visit <a href="https://www.go.gov.sg/safety-mark" rel="noopener noreferrer nofollow" target="_blank">go.gov.sg/safety-mark</a> and
-click on "Register of Registered Controlled Goods"</p>
-<p></p>
-<p><strong>Note: </strong>Our Register is down now. Please check <strong><a href="/files/Active_CG_registrations_as_of_9_Jun_2026__5pm.pdf" rel="noopener nofollow" target="_blank">this file</a></strong>,
-for the Controlled Goods with active registrations as of<strong> 9 June 2026, 5pm</strong>.</p>
+click on "Register of Registered Controlled Goods".</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
As CPSA+ has been restored, the Active CGs List has been removed from the following pages: Look for the Safety Mark, and Overview of CPSR (for Suppliers)